### PR TITLE
Exo jetpack event Tweaks and more Backend code optimization

### DIFF
--- a/src/main/java/com/lumengrid/oritechthings/block/ModBlocks.java
+++ b/src/main/java/com/lumengrid/oritechthings/block/ModBlocks.java
@@ -5,6 +5,7 @@ import com.lumengrid.oritechthings.item.ModItems;
 import com.lumengrid.oritechthings.main.ConfigLoader;
 import com.lumengrid.oritechthings.main.OritechThings;
 import com.lumengrid.oritechthings.util.Constants;
+import com.lumengrid.oritechthings.util.Constants.NameUtil;
 import com.lumengrid.oritechthings.util.ShapeUtil;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.BlockItem;
@@ -21,139 +22,136 @@ import rearth.oritech.util.Geometry;
 import java.util.function.Supplier;
 
 public class ModBlocks {
+
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(OritechThings.MOD_ID);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_2 = speedAddonBuilder(2);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_3 = speedAddonBuilder(3);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_4 = speedAddonBuilder(4);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_5 = speedAddonBuilder(5);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_6 = speedAddonBuilder(6);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_7 = speedAddonBuilder(7);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_8 = speedAddonBuilder(8);
+    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_9 = speedAddonBuilder(9);
 
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_2 = registerBlock("addon_block_speed_tier_2", () -> speedAddonBlock("addon_block_speed_tier_2", 2));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_3 = registerBlock("addon_block_speed_tier_3", () -> speedAddonBlock("addon_block_speed_tier_3", 3));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_4 = registerBlock("addon_block_speed_tier_4", () -> speedAddonBlock("addon_block_speed_tier_4", 4));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_5 = registerBlock("addon_block_speed_tier_5", () -> speedAddonBlock("addon_block_speed_tier_5", 5));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_6 = registerBlock("addon_block_speed_tier_6", () -> speedAddonBlock("addon_block_speed_tier_6", 6));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_7 = registerBlock("addon_block_speed_tier_7", () -> speedAddonBlock("addon_block_speed_tier_7", 7));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_8 = registerBlock("addon_block_speed_tier_8", () -> speedAddonBlock("addon_block_speed_tier_8", 8));
-    public static final DeferredBlock<Block> ADDON_BLOCK_SPEED_TIER_9 = registerBlock("addon_block_speed_tier_9", () -> speedAddonBlock("addon_block_speed_tier_9", 9));
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_2 = efficientSpeedAddonBuilder(2);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_3 = efficientSpeedAddonBuilder(3);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_4 = efficientSpeedAddonBuilder(4);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_5 = efficientSpeedAddonBuilder(5);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_6 = efficientSpeedAddonBuilder(6);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_7 = efficientSpeedAddonBuilder(7);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_8 = efficientSpeedAddonBuilder(8);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_9 = efficientSpeedAddonBuilder(9);
 
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_2 = registerBlock("addon_block_efficient_speed_tier_2", () -> efficientSpeedAddonBlock("addon_block_speed_tier_2", 2));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_3 = registerBlock("addon_block_efficient_speed_tier_3", () -> efficientSpeedAddonBlock("addon_block_speed_tier_3", 3));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_4 = registerBlock("addon_block_efficient_speed_tier_4", () -> efficientSpeedAddonBlock("addon_block_speed_tier_4", 4));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_5 = registerBlock("addon_block_efficient_speed_tier_5", () -> efficientSpeedAddonBlock("addon_block_speed_tier_5", 5));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_6 = registerBlock("addon_block_efficient_speed_tier_6", () -> efficientSpeedAddonBlock("addon_block_speed_tier_6", 6));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_7 = registerBlock("addon_block_efficient_speed_tier_7", () -> efficientSpeedAddonBlock("addon_block_speed_tier_7", 7));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_8 = registerBlock("addon_block_efficient_speed_tier_8", () -> efficientSpeedAddonBlock("addon_block_speed_tier_8", 8));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENT_SPEED_TIER_9 = registerBlock("addon_block_efficient_speed_tier_9", () -> efficientSpeedAddonBlock("addon_block_speed_tier_9", 9));
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_2 = efficiencyAddonBuilder(2);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_3 = efficiencyAddonBuilder(3);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_4 = efficiencyAddonBuilder(4);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_5 = efficiencyAddonBuilder(5);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_6 = efficiencyAddonBuilder(6);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_7 = efficiencyAddonBuilder(7);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_8 = efficiencyAddonBuilder(8);
+    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_9 = efficiencyAddonBuilder(9);
 
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_2 = registerBlock("addon_block_efficiency_tier_2", () -> efficiencyAddonBlock("addon_block_efficiency_tier_2", 2));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_3 = registerBlock("addon_block_efficiency_tier_3", () -> efficiencyAddonBlock("addon_block_efficiency_tier_3", 3));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_4 = registerBlock("addon_block_efficiency_tier_4", () -> efficiencyAddonBlock("addon_block_efficiency_tier_4", 4));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_5 = registerBlock("addon_block_efficiency_tier_5", () -> efficiencyAddonBlock("addon_block_efficiency_tier_5", 5));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_6 = registerBlock("addon_block_efficiency_tier_6", () -> efficiencyAddonBlock("addon_block_efficiency_tier_6", 6));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_7 = registerBlock("addon_block_efficiency_tier_7", () -> efficiencyAddonBlock("addon_block_efficiency_tier_7", 7));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_8 = registerBlock("addon_block_efficiency_tier_8", () -> efficiencyAddonBlock("addon_block_efficiency_tier_8", 8));
-    public static final DeferredBlock<Block> ADDON_BLOCK_EFFICIENCY_TIER_9 = registerBlock("addon_block_efficiency_tier_9", () -> efficiencyAddonBlock("addon_block_efficiency_tier_9", 9));
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_2 = capacitorAddonBuilder(2);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_3 = capacitorAddonBuilder(3);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_4 = capacitorAddonBuilder(4);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_5 = capacitorAddonBuilder(5);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_6 = capacitorAddonBuilder(6);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_7 = capacitorAddonBuilder(7);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_8 = capacitorAddonBuilder(8);
+    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_9 = capacitorAddonBuilder(9);
 
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_2 = registerBlock("addon_block_capacitor_tier_2", () -> capacitorAddonBlock("addon_block_capacitor_tier_2", 2));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_3 = registerBlock("addon_block_capacitor_tier_3", () -> capacitorAddonBlock("addon_block_capacitor_tier_3", 3));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_4 = registerBlock("addon_block_capacitor_tier_4", () -> capacitorAddonBlock("addon_block_capacitor_tier_4", 4));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_5 = registerBlock("addon_block_capacitor_tier_5", () -> capacitorAddonBlock("addon_block_capacitor_tier_5", 5));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_6 = registerBlock("addon_block_capacitor_tier_6", () -> capacitorAddonBlock("addon_block_capacitor_tier_6", 6));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_7 = registerBlock("addon_block_capacitor_tier_7", () -> capacitorAddonBlock("addon_block_capacitor_tier_7", 7));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_8 = registerBlock("addon_block_capacitor_tier_8", () -> capacitorAddonBlock("addon_block_capacitor_tier_8", 8));
-    public static final DeferredBlock<Block> ADDON_BLOCK_CAPACITOR_TIER_9 = registerBlock("addon_block_capacitor_tier_9", () -> capacitorAddonBlock("addon_block_capacitor_tier_9", 9));
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_2 = acceptorAddonBuilder(2);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_3 = acceptorAddonBuilder(3);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_4 = acceptorAddonBuilder(4);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_5 = acceptorAddonBuilder(5);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_6 = acceptorAddonBuilder(6);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_7 = acceptorAddonBuilder(7);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_8 = acceptorAddonBuilder(8);
+    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_9 = acceptorAddonBuilder(9);
 
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_2 = registerBlock("addon_block_acceptor_tier_2", () -> acceptorAddonBlock("addon_block_acceptor_tier_2", 2));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_3 = registerBlock("addon_block_acceptor_tier_3", () -> acceptorAddonBlock("addon_block_acceptor_tier_3", 3));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_4 = registerBlock("addon_block_acceptor_tier_4", () -> acceptorAddonBlock("addon_block_acceptor_tier_4", 4));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_5 = registerBlock("addon_block_acceptor_tier_5", () -> acceptorAddonBlock("addon_block_acceptor_tier_5", 5));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_6 = registerBlock("addon_block_acceptor_tier_6", () -> acceptorAddonBlock("addon_block_acceptor_tier_6", 6));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_7 = registerBlock("addon_block_acceptor_tier_7", () -> acceptorAddonBlock("addon_block_acceptor_tier_7", 7));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_8 = registerBlock("addon_block_acceptor_tier_8", () -> acceptorAddonBlock("addon_block_acceptor_tier_8", 8));
-    public static final DeferredBlock<Block> ADDON_BLOCK_ACCEPTOR_TIER_9 = registerBlock("addon_block_acceptor_tier_9", () -> acceptorAddonBlock("addon_block_acceptor_tier_9", 9));
-    
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_2 = registerBlock("addon_block_processing_tier_2", () -> processingAddonBlock("addon_block_processing_tier_2", 2));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_3 = registerBlock("addon_block_processing_tier_3", () -> processingAddonBlock("addon_block_processing_tier_3", 3));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_4 = registerBlock("addon_block_processing_tier_4", () -> processingAddonBlock("addon_block_processing_tier_4", 4));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_5 = registerBlock("addon_block_processing_tier_5", () -> processingAddonBlock("addon_block_processing_tier_5", 5));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_6 = registerBlock("addon_block_processing_tier_6", () -> processingAddonBlock("addon_block_processing_tier_6", 6));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_7 = registerBlock("addon_block_processing_tier_7", () -> processingAddonBlock("addon_block_processing_tier_7", 7));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_8 = registerBlock("addon_block_processing_tier_8", () -> processingAddonBlock("addon_block_processing_tier_8", 8));
-    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_9 = registerBlock("addon_block_processing_tier_9", () -> processingAddonBlock("addon_block_processing_tier_9", 9));
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_2 = processingAddonBuilder(2);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_3 = processingAddonBuilder(3);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_4 = processingAddonBuilder(4);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_5 = processingAddonBuilder(5);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_6 = processingAddonBuilder(6);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_7 = processingAddonBuilder(7);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_8 = processingAddonBuilder(8);
+    public static final DeferredBlock<Block> ADDON_BLOCK_PROCESSING_TIER_9 = processingAddonBuilder(9);
 
+    private static DeferredBlock<Block> processingAddonBuilder(int tier) {
+        return registerBlock(
+                NameUtil.genAddonName(NameUtil.Type.PROCESSING, tier), () -> new TierAddonBlock(
+                        MachineAddonBlock.AddonSettings.getDefaultSettings()
+                                .withEfficiencyMultiplier(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).processingEfficiency())
+                                .withChambers(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).processingChambers())
+                                .withNeedsSupport(true)
+                                .withBoundingShape(generateAddonShape(7)),
+                        tier, Constants.AddonType.PROCESSING));
 
-    private static Block processingAddonBlock(String name, int tier) {
-        String[] split = name.split("_");
-        int i = Integer.parseInt(split[split.length - 1]) - 2;
-        float efficiency = ConfigLoader.getInstance().addonSettings.get(i).processingEfficiency();
-        int chambers = ConfigLoader.getInstance().addonSettings.get(i).processingChambers();
-        return new TierAddonBlock(
-                MachineAddonBlock.AddonSettings.getDefaultSettings()
-                        .withEfficiencyMultiplier(efficiency)
-                        .withChambers(chambers)
-                        .withNeedsSupport(true)
-                        .withBoundingShape(generateAddonShape(7)), tier, Constants.AddonType.PROCESSING);
     }
 
-    private static Block capacitorAddonBlock(String name, int tier) {
-        String[] split = name.split("_");
-        int i = Integer.parseInt(split[split.length - 1]) - 2;
-        long capacity = ConfigLoader.getInstance().addonSettings.get(i).capacitorCapacity();
-        long rate = ConfigLoader.getInstance().addonSettings.get(i).capacitorRate();
-        return new TierAddonBlock(
-                MachineAddonBlock.AddonSettings.getDefaultSettings()
-                        .withAddedCapacity(capacity)
-                        .withAddedInsert(rate)
-                        .withNeedsSupport(true)
-                        .withBoundingShape(generateAddonShape(6)), tier, Constants.AddonType.CAPACITOR);
+    private static DeferredBlock<Block> capacitorAddonBuilder(int tier) {
+        return registerBlock(
+                NameUtil.genAddonName(NameUtil.Type.CAPACITOR, tier), () -> new TierAddonBlock(
+                        MachineAddonBlock.AddonSettings.getDefaultSettings()
+                                .withAddedCapacity(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).capacitorCapacity())
+                                .withAddedInsert(ConfigLoader.getInstance().addonSettings.get(tier - 2).capacitorRate())
+                                .withNeedsSupport(true)
+                                .withBoundingShape(generateAddonShape(6)),
+                        tier, Constants.AddonType.CAPACITOR));
     }
 
-    private static Block acceptorAddonBlock(String name, int tier) {
-        String[] split = name.split("_");
-        int i = Integer.parseInt(split[split.length - 1]) - 2;
-        long capacity = ConfigLoader.getInstance().addonSettings.get(i).acceptorCapacity();
-        long rate = ConfigLoader.getInstance().addonSettings.get(i).acceptorRate();
-        return new TierAddonBlock(
-                MachineAddonBlock.AddonSettings.getDefaultSettings()
-                        .withAddedCapacity(capacity)
-                        .withAddedInsert(rate)
-                        .withAcceptEnergy(true)
-                        .withNeedsSupport(true)
-                        .withBoundingShape(generateAddonShape(8)), tier, Constants.AddonType.ACCEPTOR);
+    private static DeferredBlock<Block> acceptorAddonBuilder(int tier) {
+        return registerBlock(
+                NameUtil.genAddonName(NameUtil.Type.ACCEPTOR, tier), () -> new TierAddonBlock(
+                        MachineAddonBlock.AddonSettings.getDefaultSettings()
+                                .withAddedCapacity(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).acceptorCapacity())
+                                .withAddedInsert(ConfigLoader.getInstance().addonSettings.get(tier - 2).acceptorRate())
+                                .withAcceptEnergy(true)
+                                .withNeedsSupport(true)
+                                .withBoundingShape(generateAddonShape(8)),
+                        tier, Constants.AddonType.ACCEPTOR));
     }
 
-
-    private static Block efficientSpeedAddonBlock(String name, int tier) {
-        String[] split = name.split("_");
-        int i = Integer.parseInt(split[split.length - 1]) - 2;
-        float speedMultiplier = ConfigLoader.getInstance().addonSettings.get(i).speedMultiplier();
-        float efficiencyMultiplier = ConfigLoader.getInstance().addonSettings.get(i).efficiencyUp();
-        return new TierAddonBlock(
-                MachineAddonBlock.AddonSettings.getDefaultSettings()
-                        .withSpeedMultiplier(speedMultiplier)
-                        .withEfficiencyMultiplier(efficiencyMultiplier)
-                        .withNeedsSupport(true)
-                        .withBoundingShape(generateAddonShape(2)), tier, Constants.AddonType.EFFICIENT_SPEED);
+    private static DeferredBlock<Block> efficientSpeedAddonBuilder(int tier) {
+        return registerBlock(
+                NameUtil.genAddonName(NameUtil.Type.EFFICIENT + NameUtil.Type.SPEED, tier), () -> new TierAddonBlock(
+                        MachineAddonBlock.AddonSettings.getDefaultSettings()
+                                .withSpeedMultiplier(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).speedMultiplier())
+                                .withEfficiencyMultiplier(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).efficiencyUp())
+                                .withNeedsSupport(true)
+                                .withBoundingShape(generateAddonShape(2)),
+                        tier, Constants.AddonType.EFFICIENT_SPEED));
     }
 
-    private static Block speedAddonBlock(String name, int tier) {
-        String[] split = name.split("_");
-        int i = Integer.parseInt(split[split.length - 1]) - 2;
-        float speedMultiplier = ConfigLoader.getInstance().addonSettings.get(i).speedMultiplier();
-        float efficiencyMultiplier = ConfigLoader.getInstance().addonSettings.get(i).efficiencyDown();
-        return new TierAddonBlock(
-                MachineAddonBlock.AddonSettings.getDefaultSettings()
-                        .withSpeedMultiplier(speedMultiplier)
-                        .withEfficiencyMultiplier(efficiencyMultiplier)
-                        .withNeedsSupport(true)
-                        .withBoundingShape(generateAddonShape(2)), tier, Constants.AddonType.SPEED);
+    private static DeferredBlock<Block> speedAddonBuilder(int tier) {
+        return registerBlock(
+                NameUtil.genAddonName(NameUtil.Type.SPEED, tier), () -> new TierAddonBlock(
+                        MachineAddonBlock.AddonSettings.getDefaultSettings()
+                                .withSpeedMultiplier(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).speedMultiplier())
+                                .withEfficiencyMultiplier(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).efficiencyDown())
+                                .withNeedsSupport(true)
+                                .withBoundingShape(generateAddonShape(2)),
+                        tier, Constants.AddonType.SPEED));
     }
 
-    private static MachineAddonBlock efficiencyAddonBlock(String name, int tier) {
-        String[] split = name.split("_");
-        int i = Integer.parseInt(split[split.length - 1]) - 2;
-        float efficiencyMultiplier = ConfigLoader.getInstance().addonSettings.get(i).efficiencyUp();
-        return new TierAddonBlock(
-                MachineAddonBlock.AddonSettings.getDefaultSettings()
-                        .withEfficiencyMultiplier(efficiencyMultiplier)
-                        .withNeedsSupport(true)
-                        .withBoundingShape(generateAddonShape(5)), tier, Constants.AddonType.EFFICIENCY);
+    private static DeferredBlock<Block> efficiencyAddonBuilder(int tier) {
+        return registerBlock(
+                NameUtil.genAddonName(NameUtil.Type.EFFICIENCY, tier), () -> new TierAddonBlock(
+                        MachineAddonBlock.AddonSettings.getDefaultSettings()
+                                .withEfficiencyMultiplier(
+                                        ConfigLoader.getInstance().addonSettings.get(tier - 2).efficiencyUp())
+                                .withNeedsSupport(true)
+                                .withBoundingShape(generateAddonShape(5)),
+                        tier, Constants.AddonType.EFFICIENCY));
     }
 
     private static VoxelShape[][] generateAddonShape(int y) {
@@ -166,8 +164,7 @@ public class ModBlocks {
                 for (AttachFace face : faces) {
                     shape[facing.ordinal()][face.ordinal()] = Shapes.or(
                             Geometry.rotateVoxelShape(ShapeUtil.shapeFromDimension(1, 0, 1, 14, y, 14), facing, face),
-                            Geometry.rotateVoxelShape(ShapeUtil.shapeFromDimension(3,2, 3, 10, y, 10), facing, face)
-                    );
+                            Geometry.rotateVoxelShape(ShapeUtil.shapeFromDimension(3, 2, 3, 10, y, 10), facing, face));
                 }
             }
         }

--- a/src/main/java/com/lumengrid/oritechthings/event/ModEvents.java
+++ b/src/main/java/com/lumengrid/oritechthings/event/ModEvents.java
@@ -14,12 +14,16 @@ import rearth.oritech.util.energy.EnergyApi;
 
 @EventBusSubscriber(modid = OritechThings.MOD_ID, bus = EventBusSubscriber.Bus.GAME)
 public class ModEvents {
+
+    @SuppressWarnings("deprecation")
     @SubscribeEvent
     public static void onPlayerTick(PlayerTickEvent.Post event) {
         if (!event.getEntity().level().isClientSide) {
             Player player = event.getEntity();
-            if (player.isCreative() || player.isSpectator()) return;
-            if (!ConfigLoader.getInstance().exoJetPackSettings.enabledCreativeFlight()) return;
+            if (player.isCreative() || player.isSpectator())
+                return;
+            if (!ConfigLoader.getInstance().exoJetPackSettings.enabledCreativeFlight())
+                return;
             ItemStack armor = player.getInventory().armor.get(2);
 
             if (armor.getItem() == ToolsContent.EXO_JETPACK.asItem()) {
@@ -29,26 +33,22 @@ public class ModEvents {
                 }
                 if (energy <= ConfigLoader.getInstance().exoJetPackSettings.rfThreshold()) {
                     if (player.getAbilities().mayfly) {
-                        player.sendSystemMessage(Component.literal("Exo Jetpack - Energy Low"));
+                        player.displayClientMessage(Component.translatable("message.exojetpack.energy_low"),true);
                     }
-                    disableCreativeFlight(player);
+                    setCreativeFlight(player,false);
                     return;
                 }
                 if (!player.getAbilities().mayfly) {
-                    enableCreativeFlight(player);
+                    setCreativeFlight(player,true);
                 }
             }
         }
     }
 
-    private static void enableCreativeFlight(Player player) {
-        player.getAbilities().mayfly = true;
-        player.onUpdateAbilities();
-    }
-
-    private static void disableCreativeFlight(Player player) {
-        player.getAbilities().flying = false;
-        player.getAbilities().mayfly = false;
+    @SuppressWarnings("deprecation")
+    private static void setCreativeFlight(Player player,Boolean bool) {
+        if(!bool) player.getAbilities().flying = bool;
+        player.getAbilities().mayfly = bool;
         player.onUpdateAbilities();
     }
 }

--- a/src/main/java/com/lumengrid/oritechthings/util/Constants.java
+++ b/src/main/java/com/lumengrid/oritechthings/util/Constants.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 public class Constants {
 
     public static DeferredBlock<?>[] SPEED = {
-        ModBlocks.ADDON_BLOCK_SPEED_TIER_2,
+            ModBlocks.ADDON_BLOCK_SPEED_TIER_2,
             ModBlocks.ADDON_BLOCK_SPEED_TIER_3,
             ModBlocks.ADDON_BLOCK_SPEED_TIER_4,
             ModBlocks.ADDON_BLOCK_SPEED_TIER_5,
@@ -19,24 +19,24 @@ public class Constants {
             ModBlocks.ADDON_BLOCK_SPEED_TIER_9,
     };
     public static DeferredBlock<?>[] EFFICIENT = {
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_2,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_3,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_4,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_5,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_6,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_7,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_8,
-        ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_9,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_2,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_3,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_4,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_5,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_6,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_7,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_8,
+            ModBlocks.ADDON_BLOCK_EFFICIENT_SPEED_TIER_9,
     };
     public static DeferredBlock<?>[] EFFICIENCY = {
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_2,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_3,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_4,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_5,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_6,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_7,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_8,
-        ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_9,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_2,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_3,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_4,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_5,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_6,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_7,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_8,
+            ModBlocks.ADDON_BLOCK_EFFICIENCY_TIER_9,
     };
     public static DeferredBlock<?>[] CAPACITOR = {
             ModBlocks.ADDON_BLOCK_CAPACITOR_TIER_2,
@@ -69,19 +69,22 @@ public class Constants {
             ModBlocks.ADDON_BLOCK_PROCESSING_TIER_9,
     };
 
-    public static int size = SPEED.length+EFFICIENCY.length+EFFICIENT.length+CAPACITOR.length+ACCEPTOR.length+PROCESSING.length;
+    public static int size = SPEED.length + EFFICIENCY.length + EFFICIENT.length + CAPACITOR.length + ACCEPTOR.length
+            + PROCESSING.length;
 
-    public static DeferredBlock<?>[] getAll(){
+    public static DeferredBlock<?>[] getAll() {
         DeferredBlock<?>[] result = new DeferredBlock<?>[size];
         System.arraycopy(SPEED, 0, result, 0, SPEED.length);
         System.arraycopy(EFFICIENCY, 0, result, SPEED.length, EFFICIENCY.length);
         System.arraycopy(EFFICIENT, 0, result, SPEED.length + EFFICIENCY.length, EFFICIENT.length);
         System.arraycopy(CAPACITOR, 0, result, SPEED.length + EFFICIENCY.length + EFFICIENT.length, CAPACITOR.length);
-        System.arraycopy(ACCEPTOR, 0, result, SPEED.length + EFFICIENCY.length + EFFICIENT.length + CAPACITOR.length, ACCEPTOR.length);
-        System.arraycopy(PROCESSING, 0, result, SPEED.length + EFFICIENCY.length + EFFICIENT.length + CAPACITOR.length+ ACCEPTOR.length, PROCESSING.length);
-            return result;
+        System.arraycopy(ACCEPTOR, 0, result, SPEED.length + EFFICIENCY.length + EFFICIENT.length + CAPACITOR.length,
+                ACCEPTOR.length);
+        System.arraycopy(PROCESSING, 0, result,
+                SPEED.length + EFFICIENCY.length + EFFICIENT.length + CAPACITOR.length + ACCEPTOR.length,
+                PROCESSING.length);
+        return result;
     }
-
 
     public enum AddonType implements StringRepresentable {
         SPEED("speed"),
@@ -104,6 +107,25 @@ public class Constants {
         public @NotNull String getSerializedName() {
             return this.name;
         }
+    }
+
+    public class NameUtil {
+        public static String BASE = "addon_block_";
+        public static String TIER = "tier_";
+
+        public class Type {
+            public static String SPEED = "speed_";
+            public static String EFFICIENT = "efficient_";
+            public static String EFFICIENCY = "efficiency_";
+            public static String CAPACITOR = "capacitor_";
+            public static String ACCEPTOR = "acceptor_";
+            public static String PROCESSING = "processing_";
+        }
+
+        public static String genAddonName(String type, int level) {
+            return BASE + type + TIER + level;
+        }
+
     }
 
 }

--- a/src/main/resources/assets/oritechthings/lang/en_us.json
+++ b/src/main/resources/assets/oritechthings/lang/en_us.json
@@ -48,5 +48,6 @@
   "block.oritechthings.addon_block_processing_tier_7": "Processing Addon Tier 7",
   "block.oritechthings.addon_block_processing_tier_8": "Processing Addon Tier 8",
   "block.oritechthings.addon_block_processing_tier_9": "Processing Addon Tier 9",
-  "tooltip.oritechthings.tiered_addons.chambers_desc": "Additional Chambers "
+  "tooltip.oritechthings.tiered_addons.chambers_desc": "Additional Chambers ",
+  "message.exojetpack.energy_low": "Exo Jetpack - Energy Low"
 }

--- a/src/main/resources/assets/oritechthings/lang/en_us.json
+++ b/src/main/resources/assets/oritechthings/lang/en_us.json
@@ -49,5 +49,5 @@
   "block.oritechthings.addon_block_processing_tier_8": "Processing Addon Tier 8",
   "block.oritechthings.addon_block_processing_tier_9": "Processing Addon Tier 9",
   "tooltip.oritechthings.tiered_addons.chambers_desc": "Additional Chambers ",
-  "message.exojetpack.energy_low": "Exo Jetpack - Energy Low"
+  "message.exojetpack.energy_low": "§c⚠ Exo Jetpack - Energy Low ⚠"
 }


### PR DESCRIPTION
## Exo Jetpack event
- added some missing `@deprecation` annotation
- changed output type : `chat` -> `actionbar`
- added red color and some ascii icons
- converted hardcoded string to traslation key to allow more customization / lang traslations
- replaced `disableCreativeFlight(player)` and `enableCreativeFlight(player)` to `setCreativeFlight(player,<boolean>)`

## Code optimization
- removed old string manipulation due "duplication parameter"
- every declared `block-addon-id` was been split on constants to allow more flexibility without need to modify everyone manually
- `<addontype>AddonBlock`  methods are now `<addontype>AddonBuilder` with return value `DeferredBlock <Block>` without need to repeat the same block-id two times
